### PR TITLE
Added link to monster page on dndbeyond for offical sources

### DIFF
--- a/scripts/monsterfactory.js
+++ b/scripts/monsterfactory.js
@@ -63,6 +63,7 @@
 
 					if ( where.match(/^\d+$/) ) {
 						out.page = Number.parseInt(where, 10);
+						out.url = "https://www.dndbeyond.com/monsters/" + monster.name.toLowerCase().split(" ").join("-")
 					} else {
 						out.url = where;
 					}


### PR DESCRIPTION
I've been using D&D Beyond for a lot of my sessions, and was finding it cumbersome to have to search for the monster every time I needed detailed stats.

This is the absolute simplest way I found of implementing this, but please let me know if you want to look at another way to handle it.