### PR TITLE
Use empty Player string for NPCs

### DIFF
--- a/app/services/integration.service.js
+++ b/app/services/integration.service.js
@@ -48,7 +48,7 @@
 					HP: { Value: monster.hp },
 					TotalInitiativeModifier: monster.init,
 					AC: { Value: monster.ac },
-					Player: "npc",
+					Player: "",
 					Id: monster.fid,
 				});
 			}


### PR DESCRIPTION
Improved Initiative now considers any non-empty string in Player to mean that the statblock is a Player Character. I've deployed a temporary fix to strip the string "npc" from imported statblocks, but this would be helpful to fix on the KFC side.