### PR TITLE
Fix maxCR == 0 not actually filtering. 

### DIFF
--- a/scripts/monsterfactory.js
+++ b/scripts/monsterfactory.js
@@ -223,11 +223,11 @@
 			}
 
 			if ( !args.skipCrCheck ) {
-				if ( filters.minCr && monster.cr.numeric < filters.minCr ) {
+				if ( (filters.minCr !== null) && monster.cr.numeric < filters.minCr ) {
 					return true;
 				}
 
-				if ( filters.maxCr && monster.cr.numeric > filters.maxCr ) {
+				if ( (filters.maxCr !== null) && monster.cr.numeric > filters.maxCr ) {
 					return true;
 				}
 			}


### PR DESCRIPTION
The CR values selected in the filter were being passed as numbers, so 0 was evaluating to falsy and not actually doing anything. Moved to a null check instead. Hit the minCr filter with the same treatment Just In Case ™️ but it's functionally the same as it was.

Closes #189.